### PR TITLE
Upgrade Go version from 1.20 to 1.21

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,8 +5,7 @@ jobs:
     strategy:
       matrix:
         go:
-          - "1.20"
-          # - "1.21"
+          - "1.21"
     name: Build
     runs-on: ubuntu-latest
     steps:

--- a/README.md
+++ b/README.md
@@ -17,9 +17,10 @@ package main
 import (
 	"context"
 
+	"log/slog"
+
 	"github.com/aws/aws-lambda-go/events"
 	"github.com/fujiwara/lamblocal"
-	"golang.org/x/exp/slog"
 )
 
 func myHandler(ctx context.Context, payload events.CloudWatchEvent) (string, error) {
@@ -39,7 +40,7 @@ In all other environments, fn is executed as a CLI (Command Line Interface) func
 
 ### Logger
 
-`lamblocal.Logger` is a logger that outputs to stderr as JSON format, using [slog](https://pkg.go.dev/golang.org/x/exp/slog).
+`lamblocal.Logger` is a logger that outputs to stderr as JSON format, using [slog](https://pkg.go.dev/log/slog).
 
 ## Limitation
 

--- a/examples/kong/go.mod
+++ b/examples/kong/go.mod
@@ -6,5 +6,6 @@ require (
 	github.com/alecthomas/kong v0.7.1
 	github.com/aws/aws-lambda-go v1.41.0
 	github.com/fujiwara/lamblocal v0.0.1
-	golang.org/x/exp v0.0.0-20230515195305-f3d0a9c9a5cc
 )
+
+require golang.org/x/exp v0.0.0-20230515195305-f3d0a9c9a5cc // indirect

--- a/examples/kong/main.go
+++ b/examples/kong/main.go
@@ -3,10 +3,11 @@ package main
 import (
 	"context"
 
+	"log/slog"
+
 	"github.com/alecthomas/kong"
 	"github.com/aws/aws-lambda-go/events"
 	"github.com/fujiwara/lamblocal"
-	"golang.org/x/exp/slog"
 )
 
 type CLI struct {

--- a/examples/simple/main.go
+++ b/examples/simple/main.go
@@ -3,9 +3,10 @@ package main
 import (
 	"context"
 
+	"log/slog"
+
 	"github.com/aws/aws-lambda-go/events"
 	"github.com/fujiwara/lamblocal"
-	"golang.org/x/exp/slog"
 )
 
 func myHandler(ctx context.Context, payload events.CloudWatchEvent) (string, error) {

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,5 @@
 module github.com/fujiwara/lamblocal
 
-go 1.20
+go 1.21
 
 require github.com/aws/aws-lambda-go v1.41.0
-
-require golang.org/x/exp v0.0.0-20230515195305-f3d0a9c9a5cc

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,10 @@
 github.com/aws/aws-lambda-go v1.41.0 h1:l/5fyVb6Ud9uYd411xdHZzSf2n86TakxzpvIoz7l+3Y=
 github.com/aws/aws-lambda-go v1.41.0/go.mod h1:jwFe2KmMsHmffA1X2R09hH6lFzJQxzI8qK17ewzbQMM=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.7.2 h1:4jaiDzPyXQvSd7D0EjG45355tLlV3VOECpq10pLC+8s=
-golang.org/x/exp v0.0.0-20230515195305-f3d0a9c9a5cc h1:mCRnTeVUjcrhlRmO0VK8a6k6Rrf6TF9htwo2pJVSjIU=
-golang.org/x/exp v0.0.0-20230515195305-f3d0a9c9a5cc/go.mod h1:V1LtkGg67GoY2N1AnLN78QLrzxkLyJw7RJb1gzOOz9w=
+github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1FQKckRals=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/lamblocal.go
+++ b/lamblocal.go
@@ -8,8 +8,9 @@ import (
 	"os"
 	"strings"
 
+	"log/slog"
+
 	"github.com/aws/aws-lambda-go/lambda"
-	"golang.org/x/exp/slog" // TODO: Go 1.21 may use "slog".
 )
 
 var Logger = slog.New(slog.NewJSONHandler(os.Stderr, nil))

--- a/lamblocal_test.go
+++ b/lamblocal_test.go
@@ -6,9 +6,10 @@ import (
 	"strings"
 	"testing"
 
+	"log/slog"
+
 	"github.com/aws/aws-lambda-go/events"
 	"github.com/fujiwara/lamblocal"
-	"golang.org/x/exp/slog"
 )
 
 func TestRunCLIOK(t *testing.T) {


### PR DESCRIPTION
Hi, @fujiwara !

[Go 1.21 is released!](https://go.dev/blog/go1.21)
So, I suggest upgrading the go version to 1.21 and using log/slog.

Thank you.