### PR TITLE
Add RunWithError

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,15 +38,26 @@ func main() {
 
 In all other environments, fn is executed as a CLI (Command Line Interface) function. In this case, the payload is read from the standard input (os.Stdin) and passed to fn. If the function returns an error, the error message is logged, and the program exits with an error code of 1.
 
+### `lamblocal.CLISrc`
+
+`lamblocal.CLISrc` is a source of the payload for the CLI execution mode. You can set the payload as a `io.Reader` instead of `os.Stdin`.
+
+```go
+lamblocal.CLISrc = strings.NewReader(`{"id": "123"}`)
+lamblocal.Run(context.TODO(), myHandler) // will call myHandler with events.{"id": "123"}
+```
+
 ### Logger
 
 `lamblocal.Logger` is a logger that outputs to stderr as JSON format, using [slog](https://pkg.go.dev/log/slog).
 
 ## Limitation
 
-Supports handler function interface `func (context.Context, interface{}) (interface{}, error)` only.
+Supports handler function interface `func (context.Context, T) (U, error)` only.
 
 [aws-lambda-go](https://github.com/aws/aws-lambda-go) supports other handler function interface `func ()` and `func (ctx context.Context)`, and etc. but lamblocal does not support them.
+
+`T` and `U` are allowed generic types that can be marshaled by `json.Marshal` and `json.Unmarshal`.
 
 ## LICENSE
 

--- a/lamblocal.go
+++ b/lamblocal.go
@@ -21,21 +21,30 @@ func init() {
 	CLISrc = os.Stdin // default
 }
 
-// Run runs a lambda hander func detect the environment (lambda or not) and run it.
+// Run runs a lambda handler func detect the environment (lambda or not) and run it.
 func Run[T any, U any](ctx context.Context, fn func(context.Context, T) (U, error)) {
+	err := RunWithError(ctx, fn)
+	if err != nil {
+		Logger.Error(err.Error())
+		os.Exit(1)
+	}
+}
+
+// RunWithError runs a lambda handler func detect the environment (lambda or not) and run it.
+func RunWithError[T any, U any](ctx context.Context, fn func(context.Context, T) (U, error)) error {
 	if strings.HasPrefix(os.Getenv("AWS_EXECUTION_ENV"), "AWS_Lambda") || os.Getenv("AWS_LAMBDA_RUNTIME_API") != "" {
 		lambda.Start(fn)
 	} else {
 		out, err := RunCLI(ctx, CLISrc, fn)
 		if err != nil {
-			Logger.Error(err.Error())
-			os.Exit(1)
+			return err
 		}
 		json.NewEncoder(os.Stdout).Encode(out)
 	}
+	return nil
 }
 
-// RunCLI is a helper function for running a lambda hander func on CLI.
+// RunCLI is a helper function for running a lambda handler func on CLI.
 func RunCLI[T any, U any](ctx context.Context, src io.Reader, fn func(context.Context, T) (U, error)) (U, error) {
 	payload := new(T)
 	if err := json.NewDecoder(src).Decode(payload); err != nil {

--- a/lamblocal_test.go
+++ b/lamblocal_test.go
@@ -2,6 +2,7 @@ package lamblocal_test
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"testing"
@@ -12,7 +13,7 @@ import (
 	"github.com/fujiwara/lamblocal"
 )
 
-func TestRunCLIOK(t *testing.T) {
+func TestRunCLI_OK(t *testing.T) {
 	handler := func(ctx context.Context, payload events.CloudWatchEvent) (string, error) {
 		lamblocal.Logger.Info("hello", slog.String("ID", payload.ID))
 		return "OK", nil
@@ -62,5 +63,20 @@ func TestRunWithPayload(t *testing.T) {
 	lamblocal.Run(context.Background(), handler)
 	if result != "OK" {
 		t.Error("unexpected result:", result)
+	}
+}
+
+func TestRunWithError(t *testing.T) {
+	e := errors.New("error")
+	handler := func(ctx context.Context, _ struct{}) (struct{}, error) {
+		return struct{}{}, e
+	}
+	lamblocal.CLISrc = strings.NewReader(`{}`)
+	err := lamblocal.RunWithError(context.Background(), handler)
+	if err == nil {
+		t.Error("error expected")
+	}
+	if err != e {
+		t.Error("unexpected error:", err)
 	}
 }


### PR DESCRIPTION
Add `lamblocal.RunWithError()`, which returns an `error` after execution only when run as a CLI.